### PR TITLE
Migrate to Python3 CI runtime

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 2.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 2.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Artifact is available at https://pypi.org/project/wrc/1.3.1/