### PR TITLE
License

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # License
 
-The WCA Regulations and Guidelines, available at [thewca/wca-regulations](https://github.com/thewca/wca-regulations), are licensed under a [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) with CC Plus "CC+" license. The CC+ grants permission to share translations of the licensed material if approved by the World Cube Association Regulations Committee.
+All WCA Regulations and Guidelines available at [thewca/wca-regulations](https://github.com/thewca/wca-regulations) published since January 1, 2023, are licensed under a [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) with CC Plus "CC+" license, unless otherwise stated. The CC+ grants permission to share translations of the licensed material, only if approved by the World Cube Association Regulations Committee.
 
 # Translation Instructions
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 - For published translations, please visit [the WCA website](https://www.worldcubeassociation.org/regulations/translations/).
 - For translation instructions, see [below](#translation-instructions).
 
+# License
+
+The WCA Regulations and Guidelines, available at [thewca/wca-regulations](https://github.com/thewca/wca-regulations), are licensed under a [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) with CC Plus "CC+" license. The CC+ grants permission to share translations of the licensed material if approved by the World Cube Association Regulations Committee.
 
 # Translation Instructions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # License
 
-All WCA Regulations and Guidelines available at [thewca/wca-regulations](https://github.com/thewca/wca-regulations) published since January 1, 2023, are licensed under a [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) with CC Plus "CC+" license, unless otherwise stated. The CC+ grants permission to share translations of the licensed material, only if approved by the World Cube Association Regulations Committee.
+All WCA Regulations and Guidelines available at [thewca/wca-regulations](https://github.com/thewca/wca-regulations) published since January 1, 2023, are licensed under a [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) with CC Plus "CC+" license, except where otherwise noted. The CC+ grants permission to share translations of the licensed material, only if approved by the World Cube Association Regulations Committee.
 
 # Translation Instructions
 


### PR DESCRIPTION
Add [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode) with [CC+](https://wiki.creativecommons.org/wiki/CCPlus#Easy_CC.2B_Markups) license.

The CC+ is a protocol provided by Creative Commons to grant rights beyond a CC license. Here we are using it to allow translations approved by the WRC to be shared (beyond the "NoDerivatives" conditions). [Here](https://www.nysenate.gov/copyright-policy) you have an example of CC+ use.